### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/src/Web/HealthChecks/SystemHealthCheck.cs
+++ b/src/Web/HealthChecks/SystemHealthCheck.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Collections.Generic;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.eShopWeb.Web.HealthChecks;
@@ -17,7 +18,12 @@ public class SystemHealthCheck : IHealthCheck
         CancellationToken cancellationToken = default(CancellationToken))
     {
         var request = _httpContextAccessor.HttpContext?.Request;
-        string drive = request.Query.ContainsKey("drive") ? request.Query["drive"] : "C";
+        string drive = request.Query.ContainsKey("drive") ? request.Query["drive"].ToString().ToUpper() : "C";
+        var allowedDrives = new HashSet<string> { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z" };
+        if (!allowedDrives.Contains(drive))
+        {
+            drive = "C";
+        }
         Process process = new Process();
         process.StartInfo.FileName = @"cmd.exe";
         process.StartInfo.Arguments = $"/C fsutil volume diskfree {drive}:";


### PR DESCRIPTION
Fixes [https://github.com/geovanams/GHAS/security/code-scanning/1](https://github.com/geovanams/GHAS/security/code-scanning/1)

To fix the problem, we need to validate the user input to ensure it is safe before using it in the command line. Specifically, we should restrict the `drive` parameter to a set of known safe values (e.g., "C", "D", etc.). This can be achieved by checking if the `drive` parameter is one of the allowed values before constructing the command line argument.

1. Define a set of allowed drive letters.
2. Check if the user-provided `drive` parameter is in the set of allowed values.
3. If it is not, use a default safe value (e.g., "C").


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
