### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/src/Web/HealthChecks/SystemHealthCheck.cs
+++ b/src/Web/HealthChecks/SystemHealthCheck.cs
@@ -19,14 +19,42 @@ public class SystemHealthCheck : IHealthCheck
     {
         var request = _httpContextAccessor.HttpContext?.Request;
         string drive = request.Query.ContainsKey("drive") ? request.Query["drive"].ToString().ToUpper() : "C";
-        var allowedDrives = new HashSet<string> { "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z" };
-        if (!allowedDrives.Contains(drive))
+        var allowedDrives = new Dictionary<string, string>
+        {
+            { "A", "/C fsutil volume diskfree A:" },
+            { "B", "/C fsutil volume diskfree B:" },
+            { "C", "/C fsutil volume diskfree C:" },
+            { "D", "/C fsutil volume diskfree D:" },
+            { "E", "/C fsutil volume diskfree E:" },
+            { "F", "/C fsutil volume diskfree F:" },
+            { "G", "/C fsutil volume diskfree G:" },
+            { "H", "/C fsutil volume diskfree H:" },
+            { "I", "/C fsutil volume diskfree I:" },
+            { "J", "/C fsutil volume diskfree J:" },
+            { "K", "/C fsutil volume diskfree K:" },
+            { "L", "/C fsutil volume diskfree L:" },
+            { "M", "/C fsutil volume diskfree M:" },
+            { "N", "/C fsutil volume diskfree N:" },
+            { "O", "/C fsutil volume diskfree O:" },
+            { "P", "/C fsutil volume diskfree P:" },
+            { "Q", "/C fsutil volume diskfree Q:" },
+            { "R", "/C fsutil volume diskfree R:" },
+            { "S", "/C fsutil volume diskfree S:" },
+            { "T", "/C fsutil volume diskfree T:" },
+            { "U", "/C fsutil volume diskfree U:" },
+            { "V", "/C fsutil volume diskfree V:" },
+            { "W", "/C fsutil volume diskfree W:" },
+            { "X", "/C fsutil volume diskfree X:" },
+            { "Y", "/C fsutil volume diskfree Y:" },
+            { "Z", "/C fsutil volume diskfree Z:" }
+        };
+        if (!allowedDrives.ContainsKey(drive))
         {
             drive = "C";
         }
         Process process = new Process();
         process.StartInfo.FileName = @"cmd.exe";
-        process.StartInfo.Arguments = $"/C fsutil volume diskfree {drive}:";
+        process.StartInfo.Arguments = allowedDrives[drive];
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.UseShellExecute = false;
         process.Start();


### PR DESCRIPTION
Fixes [https://github.com/geovanams/GHAS/security/code-scanning/1](https://github.com/geovanams/GHAS/security/code-scanning/1)

To fix the problem, we should avoid using user input directly in the command line arguments. Instead, we can use a mapping of allowed drive letters to their corresponding commands. This ensures that only predefined, safe commands are executed.

- Create a dictionary that maps allowed drive letters to their corresponding `fsutil` commands.
- Use the dictionary to look up the command based on the validated `drive` value.
- This approach ensures that only predefined commands are executed, eliminating the risk of command injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
